### PR TITLE
Move docker push to semaphore promotions

### DIFF
--- a/.semaphore/build-and-push-docker-latest.yml
+++ b/.semaphore/build-and-push-docker-latest.yml
@@ -1,0 +1,24 @@
+version: v1.0
+name: Push docker latest image
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+blocks:
+  - name: Push
+    task:
+      prologue:
+        commands:
+          - checkout
+          - echo $DOCKER_PASSWORD | docker login --username "$DOCKER_USERNAME" --password-stdin
+          - cp .env.example .env
+          - docker-compose pull tests || true
+      jobs:
+        - name: 'Build an push image to Docker Hub'
+          commands:
+            - TAG=$SEMAPHORE_GIT_SHA docker-compose build kms
+            - docker tag philippks/kms:$SEMAPHORE_GIT_SHA philippks/kms:latest
+            - docker push philippks/kms:$SEMAPHORE_GIT_SHA
+            - docker push philippks/kms:latest
+      secrets:
+        - name: docker

--- a/.semaphore/build-and-push-docker-staging-latest.yml
+++ b/.semaphore/build-and-push-docker-staging-latest.yml
@@ -1,0 +1,22 @@
+version: v1.0
+name: Push docker staging-latest image
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+blocks:
+  - name: Push
+    task:
+      prologue:
+        commands:
+          - checkout
+          - echo $DOCKER_PASSWORD | docker login --username "$DOCKER_USERNAME" --password-stdin
+          - cp .env.example .env
+          - docker-compose pull tests || true
+      jobs:
+        - name: 'Build an push staging image to Docker Hub'
+          commands:
+            - TAG=staging-latest docker-compose build kms
+            - docker push philippks/kms:staging-latest
+      secrets:
+        - name: docker

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -6,7 +6,7 @@ agent:
 execution_time_limit:
   minutes: 30
 blocks:
-  - name: "Run Tests and Push Docker Image"
+  - name: "Run Tests"
     task:
       prologue:
         commands:
@@ -15,13 +15,15 @@ blocks:
           - cp .env.example .env
           - docker-compose pull tests || true
       jobs:
-        - name: "Run Tests and Push Docker Image"
+        - name: "Run Tests"
           commands:
             - docker-compose build tests
             - docker-compose push tests
             - docker-compose run tests
-            - if [ $SEMAPHORE_GIT_REF_TYPE == "branch" -a $SEMAPHORE_GIT_BRANCH == "master" ]; then TAG=$SEMAPHORE_GIT_SHA docker-compose build kms; fi
-            - if [ $SEMAPHORE_GIT_REF_TYPE == "branch" -a $SEMAPHORE_GIT_BRANCH == "master" ]; then docker tag philippks/kms:$SEMAPHORE_GIT_SHA philippks/kms:latest; fi
-            - if [ $SEMAPHORE_GIT_REF_TYPE == "branch" -a $SEMAPHORE_GIT_BRANCH == "master" ]; then docker push philippks/kms:$SEMAPHORE_GIT_SHA; docker push philippks/kms:latest; fi
       secrets:
         - name: docker
+promotions:
+  - name: Build and push docker staging-latest image
+    pipeline_file: build-and-push-docker-staging-latest.yml
+  - name: Build and push docker latest image
+    pipeline_file: build-and-push-docker-latest.yml


### PR DESCRIPTION
Master commits are now not pushed to docker hub by default. By using
semaphore promotions, they are pushed when one clicks on the
corresponding button in the semaphore web interface. This way, the way
of deploying is better controlled.