### PR TITLE
Pass resources to services by method param and not constructor

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -21,7 +21,7 @@ class ActivitiesController < ApplicationController
       end
 
       format.csv do
-        send_data ActivitiesCsv.new(@activities).to_csv, filename: "#{export_file_name}.csv"
+        send_data ActivitiesCsv.new.to_csv(@activities), filename: "#{export_file_name}.csv"
       end
     end
   end

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -22,7 +22,7 @@ class InvoicesController < ApplicationController
       end
 
       format.csv do
-        send_data InvoicesCsv.new(@invoices).to_csv, filename: "#{export_file_name}.csv"
+        send_data InvoicesCsv.new.to_csv(@invoices), filename: "#{export_file_name}.csv"
       end
     end
   end

--- a/app/services/activities_csv.rb
+++ b/app/services/activities_csv.rb
@@ -16,14 +16,10 @@ class ActivitiesCsv
 
   }.freeze
 
-  def initialize(activitys)
-    @activitys = activitys
-  end
-
-  def to_csv
+  def to_csv(activities)
     CSV.generate do |csv|
       csv << COLUMNS.keys.map(&Activity.method(:human_attribute_name))
-      @activitys.each do |activity|
+      activities.each do |activity|
         csv << COLUMNS.values.map { |column| column.call(activity) }
       end
     end

--- a/app/services/invoices_csv.rb
+++ b/app/services/invoices_csv.rb
@@ -11,14 +11,10 @@ class InvoicesCsv
 
   }.freeze
 
-  def initialize(invoices)
-    @invoices = invoices
-  end
-
-  def to_csv
+  def to_csv(invoices)
     CSV.generate do |csv|
       csv << COLUMNS.keys.map(&Invoice.method(:human_attribute_name))
-      @invoices.each do |invoice|
+      invoices.each do |invoice|
         csv << COLUMNS.values.map { |column| column.call(invoice) }
       end
     end

--- a/spec/services/activities_csv_spec.rb
+++ b/spec/services/activities_csv_spec.rb
@@ -7,7 +7,7 @@ describe ActivitiesCsv do
 
   describe '#to_csv' do
     it 'returns CSV with activities data' do
-      expect(described_class.new([activity]).to_csv).to eq <<~CSV
+      expect(described_class.new.to_csv([activity])).to eq <<~CSV
         ID,Mitarbeiter,Kunde,Datum,Anzahl Stunden,Stundensatz,Betrag,Rechnungstext,Notiz,Status,Leistungskategorie
         #{activity.id},Irgendein Mitarbeiter,Irgendein Kunde,18.02.2015,10.0,150.00,1'500.00,Steuererklärung ausgefüllt,"",Offen,Buchhaltung
       CSV

--- a/spec/services/invoices_csv_spec.rb
+++ b/spec/services/invoices_csv_spec.rb
@@ -12,7 +12,7 @@ describe InvoicesCsv do
     end
 
     it 'returns CSV with invoices data' do
-      expect(described_class.new([invoice]).to_csv).to eq <<~CSV
+      expect(described_class.new.to_csv([invoice])).to eq <<~CSV
         ID,Mitarbeiter,Kunde,Rechnungsdatum,Betrag,Status
         #{invoice.id},Irgendein Mitarbeiter,Irgendein Kunde,#{I18n.l(invoice.date)},1'015.00,Offen
       CSV


### PR DESCRIPTION
Based on the advise of the book "Sustainable Web Development with Rails":

> Collecting parameters in one method (the constructor) and using them
in another (call) splits up core logic for no benefit. It also can make complex routines more difficult to understand since parameters are initialized far from where they are used.